### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/tasosvaf/3e36ea78-643b-4e89-8919-1e2730814ab7/bfc120e8-518f-4813-a2e7-a7cd75db0ca1/_apis/work/boardbadge/dfc1f15b-fc01-4aed-8022-3e053c21e3b1)](https://dev.azure.com/tasosvaf/3e36ea78-643b-4e89-8919-1e2730814ab7/_boards/board/t/bfc120e8-518f-4813-a2e7-a7cd75db0ca1/Microsoft.RequirementCategory)
 # TestProject1000


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/tasosvaf/3e36ea78-643b-4e89-8919-1e2730814ab7/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.